### PR TITLE
(feature) Optionally Prepend Story Type [ch46063]

### DIFF
--- a/.github/workflows/gh-pr-opened.yml
+++ b/.github/workflows/gh-pr-opened.yml
@@ -11,7 +11,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           path: action
-          ref: ${{ github.payload.pull_request.head.ref }}
 
       - name: Update PR
         uses: './action'

--- a/.github/workflows/gh-pr-opened.yml
+++ b/.github/workflows/gh-pr-opened.yml
@@ -11,6 +11,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           path: action
+          ref: ${{ github.payload.pull_request.head.ref }}
 
       - name: Update PR
         uses: './action'

--- a/.github/workflows/gh-pr-opened.yml
+++ b/.github/workflows/gh-pr-opened.yml
@@ -9,9 +9,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          path: action
 
       - name: Update PR
-        uses: ${{ github.workspace }}
+        uses: './action'
         with:
           ghToken: ${{ secrets.GITHUB_TOKEN }}
           chToken: ${{ secrets.CLUBHOUSE_TOKEN }}

--- a/.github/workflows/gh-pr-opened.yml
+++ b/.github/workflows/gh-pr-opened.yml
@@ -2,7 +2,7 @@ name: Update PR Title & Body with Clubhouse Info
 
 on:
   pull_request:
-    types: [opened]
+    types: [opened, reopened]
 
 jobs:
   update:

--- a/.github/workflows/gh-pr-opened.yml
+++ b/.github/workflows/gh-pr-opened.yml
@@ -1,0 +1,17 @@
+name: Update PR Title & Body with Clubhouse Info
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Update PR
+        uses: ${{ github.workspace }}
+        with:
+          ghToken: ${{ secrets.GITHUB_TOKEN }}
+          chToken: ${{ secrets.CLUBHOUSE_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ on:
 ```
 
 ```
-uses: actions/clubhouse-pr@v1
+uses: actions/clubhouse-pr@v2
 with:
   ghToken: ${{ secrets.GITHUB_TOKEN }}
   chToken: ${{ secrets.CLUBHOUSE_API_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 [![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)
 ![Test](https://github.com/farmersdog/clubhouse-pr/workflows/Test/badge.svg)
 
-Automatically update your Github Pull Request with a Clubhouse title in the format: `(feat) Some Feature [ch123]`. And
-adds the Clubhouse story's URL to the beginning of the body of your PR.
+Automatically update your Github Pull Request with data from your clubhouse story in the format: `(feat) Some Feature [ch123]`. Also adds the clubhouse story's URL to the beginning of the body of your PR.
+
+This action is configured to extract the clubhouse story id form either the branch or title. It works best if you use the builtin [git helpers](https://help.clubhouse.io/hc/en-us/articles/207540323-Using-Branches-and-Pull-Requests-with-the-Clubhouse-VCS-Integrations) to generate your branch names.
 
 ## Inputs
 
@@ -15,6 +16,18 @@ adds the Clubhouse story's URL to the beginning of the body of your PR.
 ### `chToken`
 
 **Required** Clubhouse API Token
+
+### `addStoryType`
+
+**Optional** Boolean to enable or disable prepending the story type to the PR title
+
+**Default** `true`
+
+### `useStoryNameTrigger`
+
+**Optional** When a PR is opened with this string as the title, fetch the story name from clubhouse
+
+**Default** `ch`
 
 ## Outputs
 
@@ -45,4 +58,82 @@ uses: actions/clubhouse-pr@v1
 with:
   ghToken: ${{ secrets.GITHUB_TOKEN }}
   chToken: ${{ secrets.CLUBHOUSE_API_TOKEN }}
+```
+
+## Example Transformations
+
+The below assumes we are working on a clubhouse story with the following parameters
+
+Name: `A cool new feature`
+
+Story Type: `feature`
+
+Story ID: `56789`
+
+### Using the clubhouse story name for a PR title
+
+#### A PR Opened As...
+
+**Title**
+
+```
+ch
+```
+
+**Body**
+
+```
+- We did a thing
+- Another thing
+- Yay feature
+```
+
+#### Is updated to...
+
+**Title**
+
+```
+(feature) A cool new feature [ch56789]
+```
+
+**Body**
+
+```
+Story details: https://app.clubhouse.io/farmersdog/story/56789
+
+- We did a thing
+- Another thing
+- Yay feature
+```
+
+### Using a custom PR title (aka don't use the story name)
+
+#### A PR Opened As...
+
+**Title**
+
+```
+We ended up not needing the cool new feature, tweaked a thing instead
+```
+
+**Body**
+
+```
+- This was an easy one, not much to say
+```
+
+#### Is updated to...
+
+**Title**
+
+```
+(feature) We ended up not needing this, tweaked a thing instead [ch56789]
+```
+
+**Body**
+
+```
+Story details: https://app.clubhouse.io/farmersdog/story/56789
+
+- This was an easy one, not much to say
 ```

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
     required: false
     default: 'true'
   useStoryNameTrigger:
-    description: 'If a PR is opened with this string as the title, fetch the story name from clubhouse'
+    description: 'When a PR is opened with this string as the title, fetch the story name from clubhouse'
     required: false
     default: 'ch'
 runs:

--- a/action.yml
+++ b/action.yml
@@ -7,11 +7,11 @@ inputs:
   chToken:
     description: 'Clubhouse API token'
     required: true
-  prependType:
+  addStoryType:
     description: 'Boolean to enable or disable prepending the story type to the PR title'
     required: false
     default: 'true'
-  fetchStoryNameFlag:
+  useStoryNameTrigger:
     description: 'If a PR is opened with this string as the title, fetch the story name from clubhouse'
     required: false
     default: 'ch'

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,10 @@ inputs:
   chToken:
     description: 'Clubhouse API token'
     required: true
+  prependType:
+    description: 'Boolean to enable or disable prepending the story type to the PR title'
+    required: false
+    default: 'true'
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,10 @@ inputs:
     description: 'Boolean to enable or disable prepending the story type to the PR title'
     required: false
     default: 'true'
+  fetchStoryNameFlag:
+    description: 'If a PR is opened with this string as the title, fetch the story name from clubhouse'
+    required: false
+    default: 'ch'
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -88,7 +88,7 @@ async function updatePullRequest(ghToken, pullRequest, repository, metadata) {
   const body = `Story Details: ${url} \n \n${originalBody}`;
 
   try {
-    core.info(`Updating Title: ${title}`)
+    core.info(`Updating Title: ${title}`);
     return await octokit.pulls.update({
       repo,
       owner: login,
@@ -101,13 +101,7 @@ async function updatePullRequest(ghToken, pullRequest, repository, metadata) {
   }
 }
 
-async function getTitle(
-  storyIds,
-  story,
-  prTitle,
-  useStoryNameTrigger,
-  addStoryType
-) {
+function getTitle(storyIds, story, prTitle, useStoryNameTrigger, addStoryType) {
   const formattedStoryIds = storyIds.map((id) => `[ch${id}]`).join(' ');
   const basePrTitle = prTitle === useStoryNameTrigger ? story.name : prTitle;
   const typePrefix = addStoryType ? `(${story.story_type}) ` : '';
@@ -173,7 +167,7 @@ async function run() {
       repository,
       dryRun: false,
     };
-    const prTitle = fetchStoryAndUpdatePr(params);
+    const prTitle = await fetchStoryAndUpdatePr(params);
 
     return core.setOutput('prTitle', prTitle);
   } catch (error) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -11,7 +11,6 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony export */   "formatMatches": () => /* binding */ formatMatches,
 /* harmony export */   "getStoryIds": () => /* binding */ getStoryIds,
 /* harmony export */   "getClubhouseStory": () => /* binding */ getClubhouseStory,
-/* harmony export */   "updatePullRequest": () => /* binding */ updatePullRequest,
 /* harmony export */   "getTitle": () => /* binding */ getTitle,
 /* harmony export */   "fetchStoryAndUpdatePr": () => /* binding */ fetchStoryAndUpdatePr,
 /* harmony export */   "run": () => /* binding */ run
@@ -78,12 +77,7 @@ async function getClubhouseStory(client, storyIds) {
   }
 }
 
-async function updatePullRequest(
-  pullRequest,
-  repository,
-  metadata,
-  ghToken
-) {
+async function updatePullRequest(ghToken, pullRequest, repository, metadata) {
   const octokit = github.getOctokit(ghToken);
   const {
     name: repo,
@@ -114,10 +108,7 @@ async function getTitle(
   addStoryType
 ) {
   const formattedStoryIds = storyIds.map((id) => `[ch${id}]`).join(' ');
-  core.info(`PR Title: ${prTitle}`);
-  core.info(`Story Name Trigger: ${useStoryNameTrigger}`);
   const basePrTitle = prTitle === useStoryNameTrigger ? story.name : prTitle;
-  core.info(`Base PR Title: ${basePrTitle}`);
   const typePrefix = addStoryType ? `(${story.story_type}) ` : '';
   const newTitle = `${typePrefix}${basePrTitle} ${formattedStoryIds}`;
   return newTitle;
@@ -193,6 +184,8 @@ async function run() {
 if (process.env.GITHUB_ACTIONS) {
   run();
 }
+
+
 
 
 /***/ }),

--- a/dist/index.js
+++ b/dist/index.js
@@ -88,6 +88,7 @@ async function updatePullRequest(ghToken, pullRequest, repository, metadata) {
   const body = `Story Details: ${url} \n \n${originalBody}`;
 
   try {
+    core.info(`Updating Title: ${title}`)
     return await octokit.pulls.update({
       repo,
       owner: login,

--- a/index.js
+++ b/index.js
@@ -88,6 +88,10 @@ export async function updatePullRequest(githubCtx, metadata) {
   }
 }
 
+export async function createPrTitle(storyName, formattedStoryIds) {
+  return `${storyName} ${formattedStoryIds}`;
+}
+
 export async function run() {
   try {
     const ghToken = core.getInput('ghToken');
@@ -110,14 +114,14 @@ export async function run() {
     const storyIds = getStoryIds(github.context);
     const story = await getClubhouseStory(client, storyIds);
     const formattedStoryIds = storyIds.map((id) => `[ch${id}]`).join(' ');
-    const storyNameAndId = `${story.name} ${formattedStoryIds}`;
+    const prTitle = createPrTitle(story.name, formattedStoryIds);
 
     await updatePullRequest(github.context, {
-      title: storyNameAndId,
+      title: prTitle,
       url: story.app_url,
     });
 
-    return core.setOutput('prTitle', storyNameAndId);
+    return core.setOutput('prTitle', prTitle);
   } catch (error) {
     return core.setFailed(error.message);
   }

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ const core = require('@actions/core');
 const github = require('@actions/github');
 const Clubhouse = require('clubhouse-lib');
 
-export function formatMatches(matches) {
+function formatMatches(matches) {
   const values = [];
 
   matches.forEach((match) => {
@@ -14,7 +14,7 @@ export function formatMatches(matches) {
   return values;
 }
 
-export function getStoryIds(pullRequest) {
+function getStoryIds(pullRequest) {
   const branchName = pullRequest.head.ref;
   // Only when a Github user formats their branchName as: text/ch123/something
   const branchStoryIds = branchName.match(/\/(ch)(\d+)\//g);
@@ -48,7 +48,7 @@ export function getStoryIds(pullRequest) {
   );
 }
 
-export async function getClubhouseStory(client, storyIds) {
+async function getClubhouseStory(client, storyIds) {
   // Even if there's more than one storyId, fetch only first story name:
   try {
     return client
@@ -60,12 +60,7 @@ export async function getClubhouseStory(client, storyIds) {
   }
 }
 
-export async function updatePullRequest(
-  ghToken,
-  pullRequest,
-  repository,
-  metadata
-) {
+async function updatePullRequest(ghToken, pullRequest, repository, metadata) {
   const octokit = github.getOctokit(ghToken);
   const {
     name: repo,
@@ -88,7 +83,7 @@ export async function updatePullRequest(
   }
 }
 
-export async function getTitle(
+async function getTitle(
   storyIds,
   story,
   prTitle,
@@ -102,7 +97,7 @@ export async function getTitle(
   return newTitle;
 }
 
-export async function fetchStoryAndUpdatePr(params) {
+async function fetchStoryAndUpdatePr(params) {
   const {
     ghToken,
     chToken,
@@ -133,7 +128,7 @@ export async function fetchStoryAndUpdatePr(params) {
   return newTitle;
 }
 
-export async function run() {
+async function run() {
   try {
     const ghToken = core.getInput('ghToken');
     const chToken = core.getInput('chToken');
@@ -172,3 +167,12 @@ export async function run() {
 if (process.env.GITHUB_ACTIONS) {
   run();
 }
+
+export {
+  formatMatches,
+  getStoryIds,
+  getClubhouseStory,
+  getTitle,
+  fetchStoryAndUpdatePr,
+  run,
+};

--- a/index.js
+++ b/index.js
@@ -92,6 +92,7 @@ export async function run() {
   try {
     const ghToken = core.getInput('ghToken');
     const chToken = core.getInput('chToken');
+    const prependType = core.getInput('prependType');
 
     if (!ghToken) {
       return core.setFailed('Input ghToken is required.');

--- a/index.js
+++ b/index.js
@@ -88,10 +88,6 @@ export async function updatePullRequest(githubCtx, metadata) {
   }
 }
 
-export async function createPrTitle(basePrTitle, formattedStoryIds) {
-  return `${storyName} ${formattedStoryIds}`;
-}
-
 export async function run() {
   try {
     const ghToken = core.getInput('ghToken');
@@ -117,7 +113,8 @@ export async function run() {
     const story = await getClubhouseStory(client, storyIds);
     const formattedStoryIds = storyIds.map((id) => `[ch${id}]`).join(' ');
     const basePrTitle = pullRequest.title === fetchStoryNameFlag ? story.name : pullRequest.title;
-    const prTitle = createPrTitle(basePrTitle, formattedStoryIds);
+    const typePrefix = prependType ? `${story.type} ` : '';
+    const prTitle = `${typePrefix}${basePrTitle} ${formattedStoryIds}`;
 
     await updatePullRequest(github.context, {
       title: prTitle,

--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ export async function updatePullRequest(githubCtx, metadata) {
   }
 }
 
-export async function createPrTitle(storyName, formattedStoryIds) {
+export async function createPrTitle(basePrTitle, formattedStoryIds) {
   return `${storyName} ${formattedStoryIds}`;
 }
 
@@ -111,11 +111,13 @@ export async function run() {
     core.setSecret('ghToken');
     core.setSecret('chToken');
 
+    const { pull_request: pullRequest } = github.context.payload;
     const client = Clubhouse.create(chToken);
     const storyIds = getStoryIds(github.context);
     const story = await getClubhouseStory(client, storyIds);
     const formattedStoryIds = storyIds.map((id) => `[ch${id}]`).join(' ');
-    const prTitle = createPrTitle(story.name, formattedStoryIds);
+    const basePrTitle = pullRequest.title === fetchStoryNameFlag ? story.name : pullRequest.title;
+    const prTitle = createPrTitle(basePrTitle, formattedStoryIds);
 
     await updatePullRequest(github.context, {
       title: prTitle,

--- a/index.js
+++ b/index.js
@@ -71,6 +71,7 @@ async function updatePullRequest(ghToken, pullRequest, repository, metadata) {
   const body = `Story Details: ${url} \n \n${originalBody}`;
 
   try {
+    core.info(`Updating Title: ${title}`);
     return await octokit.pulls.update({
       repo,
       owner: login,

--- a/index.js
+++ b/index.js
@@ -84,13 +84,7 @@ async function updatePullRequest(ghToken, pullRequest, repository, metadata) {
   }
 }
 
-async function getTitle(
-  storyIds,
-  story,
-  prTitle,
-  useStoryNameTrigger,
-  addStoryType
-) {
+function getTitle(storyIds, story, prTitle, useStoryNameTrigger, addStoryType) {
   const formattedStoryIds = storyIds.map((id) => `[ch${id}]`).join(' ');
   const basePrTitle = prTitle === useStoryNameTrigger ? story.name : prTitle;
   const typePrefix = addStoryType ? `(${story.story_type}) ` : '';

--- a/index.js
+++ b/index.js
@@ -61,10 +61,10 @@ export async function getClubhouseStory(client, storyIds) {
 }
 
 export async function updatePullRequest(
+  ghToken,
   pullRequest,
   repository,
-  metadata,
-  ghToken
+  metadata
 ) {
   const octokit = github.getOctokit(ghToken);
   const {

--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ export async function updatePullRequest(
   } = repository;
   const { title, url } = metadata;
   const originalBody = pullRequest.body;
-  const body = `${url} \n \n${originalBody}`;
+  const body = `Story Details: ${url} \n \n${originalBody}`;
 
   try {
     return await octokit.pulls.update({

--- a/index.js
+++ b/index.js
@@ -102,7 +102,7 @@ export async function getTitle(
   return newTitle;
 }
 
-export async function fetchStorysAndUpdatePr(params) {
+export async function fetchStoryAndUpdatePr(params) {
   const {
     ghToken,
     chToken,
@@ -160,7 +160,7 @@ export async function run() {
       repository,
       dryRun: false,
     };
-    const prTitle = fetchStorysAndUpdatePr(params);
+    const prTitle = fetchStoryAndUpdatePr(params);
 
     return core.setOutput('prTitle', prTitle);
   } catch (error) {

--- a/index.js
+++ b/index.js
@@ -96,10 +96,10 @@ export async function getTitle(
   addStoryType
 ) {
   const formattedStoryIds = storyIds.map((id) => `[ch${id}]`).join(' ');
-  console.log(`PR Title: ${prTitle}`);
-  console.log(`Story Name Trigger: ${useStoryNameTrigger}`);
+  core.info(`PR Title: ${prTitle}`);
+  core.info(`Story Name Trigger: ${useStoryNameTrigger}`);
   const basePrTitle = prTitle === useStoryNameTrigger ? story.name : prTitle;
-  console.log(`Base PR Title: ${basePrTitle}`);
+  core.info(`Base PR Title: ${basePrTitle}`);
   const typePrefix = addStoryType ? `(${story.story_type}) ` : '';
   const newTitle = `${typePrefix}${basePrTitle} ${formattedStoryIds}`;
   return newTitle;

--- a/index.js
+++ b/index.js
@@ -96,7 +96,10 @@ export async function getTitle(
   addStoryType
 ) {
   const formattedStoryIds = storyIds.map((id) => `[ch${id}]`).join(' ');
+  console.log(`PR Title: ${prTitle}`);
+  console.log(`Story Name Trigger: ${useStoryNameTrigger}`);
   const basePrTitle = prTitle === useStoryNameTrigger ? story.name : prTitle;
+  console.log(`Base PR Title: ${basePrTitle}`);
   const typePrefix = addStoryType ? `(${story.story_type}) ` : '';
   const newTitle = `${typePrefix}${basePrTitle} ${formattedStoryIds}`;
   return newTitle;

--- a/index.js
+++ b/index.js
@@ -105,7 +105,7 @@ export async function fetchStorysAndUpdatePr(params) {
   const formattedStoryIds = storyIds.map((id) => `[ch${id}]`).join(' ');
   const basePrTitle =
     pullRequest.title === fetchStoryNameFlag ? story.name : pullRequest.title;
-  const typePrefix = prependType ? `${story.type} ` : '';
+  const typePrefix = prependType ? `(${story.story_type}) ` : '';
   const prTitle = `${typePrefix}${basePrTitle} ${formattedStoryIds}`;
 
   if (!dryRun) {
@@ -153,4 +153,7 @@ export async function run() {
   }
 }
 
-run();
+// Always true in the actions env
+if (process.env.GITHUB_ACTIONS) {
+  run();
+}

--- a/index.js
+++ b/index.js
@@ -97,6 +97,7 @@ export async function run() {
     const ghToken = core.getInput('ghToken');
     const chToken = core.getInput('chToken');
     const prependType = core.getInput('prependType');
+    const fetchStoryNameFlag = core.getInput('fetchStoryNameFlag');
 
     if (!ghToken) {
       return core.setFailed('Input ghToken is required.');

--- a/index.js
+++ b/index.js
@@ -96,10 +96,7 @@ export async function getTitle(
   addStoryType
 ) {
   const formattedStoryIds = storyIds.map((id) => `[ch${id}]`).join(' ');
-  core.info(`PR Title: ${prTitle}`);
-  core.info(`Story Name Trigger: ${useStoryNameTrigger}`);
   const basePrTitle = prTitle === useStoryNameTrigger ? story.name : prTitle;
-  core.info(`Base PR Title: ${basePrTitle}`);
   const typePrefix = addStoryType ? `(${story.story_type}) ` : '';
   const newTitle = `${typePrefix}${basePrTitle} ${formattedStoryIds}`;
   return newTitle;

--- a/index.js
+++ b/index.js
@@ -150,7 +150,7 @@ async function run() {
       repository,
       dryRun: false,
     };
-    const prTitle = fetchStoryAndUpdatePr(params);
+    const prTitle = await fetchStoryAndUpdatePr(params);
 
     return core.setOutput('prTitle', prTitle);
   } catch (error) {

--- a/index.test.js
+++ b/index.test.js
@@ -45,6 +45,45 @@ describe('Update Pull Request', () => {
     });
   });
 
+  describe('Creating the PR Title', () => {
+    test('should use story name from clubhouse as title', async () => {
+      const prTitle = await action.getTitle(
+        ['5678'],
+        { name: 'A clubhouse story name', story_type: 'feature' },
+        'ch',
+        'ch',
+        true
+      );
+      expect(prTitle).toEqual('(feature) A clubhouse story name [ch5678]');
+    });
+
+    test('should not use story name from clubhouse as title', async () => {
+      const prTitle = await action.getTitle(
+        ['5678'],
+        { name: 'A clubhouse story name', story_type: 'feature' },
+        'A PR title that should not be replaced',
+        'ch',
+        true
+      );
+      expect(prTitle).toEqual(
+        '(feature) A PR title that should not be replaced [ch5678]'
+      );
+    });
+
+    test('should not add story type when option is false', async () => {
+      const prTitle = await action.getTitle(
+        ['5678'],
+        { name: 'A clubhouse story name', story_type: 'feature' },
+        'A PR title that should not be replaced',
+        'ch',
+        false
+      );
+      expect(prTitle).toEqual(
+        'A PR title that should not be replaced [ch5678]'
+      );
+    });
+  });
+
   describe('getStoryIds', () => {
     test('should return storyIds from branchName', () => {
       const { pull_request: pullRequest } = github.context.payload;

--- a/index.test.js
+++ b/index.test.js
@@ -47,46 +47,35 @@ describe('Update Pull Request', () => {
 
   describe('getStoryIds', () => {
     test('should return storyIds from branchName', () => {
-      expect(action.getStoryIds(github.context)).toEqual(['1']);
+      const { pull_request: pullRequest } = github.context.payload;
+      expect(action.getStoryIds(pullRequest)).toEqual(['1']);
     });
 
     test('should return [ch#] storyIds from PR title', () => {
-      github.context = {
-        payload: {
-          pull_request: {
-            title: '[ch2]',
-            head: { ref: 'i-named-this-in-a-diff-format' },
-          },
-        },
+      const pullRequest = {
+        title: '[ch2]',
+        head: { ref: 'i-named-this-in-a-diff-format' },
       };
 
-      expect(action.getStoryIds(github.context)).toEqual(['2']);
+      expect(action.getStoryIds(pullRequest)).toEqual(['2']);
     });
 
     test('should return ch# storyIds from PR title', () => {
-      github.context = {
-        payload: {
-          pull_request: {
-            title: 'ch2',
-            head: { ref: 'i-named-this-in-a-diff-format' },
-          },
-        },
+      const pullRequest = {
+        title: 'ch2',
+        head: { ref: 'i-named-this-in-a-diff-format' },
       };
 
-      expect(action.getStoryIds(github.context)).toEqual(['2']);
+      expect(action.getStoryIds(pullRequest)).toEqual(['2']);
     });
 
     test('should exit if no ch id in PR title or branchName', () => {
-      github.context = {
-        payload: {
-          pull_request: {
-            title: 'I have nothing related to ch ids in my title',
-            head: { ref: 'i-dont-have-a-ch-id-in-here' },
-          },
-        },
+      const pullRequest = {
+        title: 'I have nothing related to ch ids in my title',
+        head: { ref: 'i-dont-have-a-ch-id-in-here' },
       };
 
-      action.getStoryIds(github.context);
+      action.getStoryIds(pullRequest);
       expect(core.setFailed).toHaveBeenCalledTimes(1);
     });
   });

--- a/index.test.js
+++ b/index.test.js
@@ -47,7 +47,7 @@ describe('Update Pull Request', () => {
 
   describe('Creating the PR Title', () => {
     test('should use story name from clubhouse as title', async () => {
-      const prTitle = await action.getTitle(
+      const prTitle = action.getTitle(
         ['5678'],
         { name: 'A clubhouse story name', story_type: 'feature' },
         'ch',
@@ -58,7 +58,7 @@ describe('Update Pull Request', () => {
     });
 
     test('should not use story name from clubhouse as title', async () => {
-      const prTitle = await action.getTitle(
+      const prTitle = action.getTitle(
         ['5678'],
         { name: 'A clubhouse story name', story_type: 'feature' },
         'A PR title that should not be replaced',
@@ -71,7 +71,7 @@ describe('Update Pull Request', () => {
     });
 
     test('should not add story type when option is false', async () => {
-      const prTitle = await action.getTitle(
+      const prTitle = action.getTitle(
         ['5678'],
         { name: 'A clubhouse story name', story_type: 'feature' },
         'A PR title that should not be replaced',

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "devDependencies": {
     "@babel/core": "^7.11.6",
     "@babel/preset-env": "^7.11.5",
+    "@babel/register": "^7.12.1",
     "@vercel/ncc": "^0.24.1",
     "babel-jest": "^26.3.0",
     "eslint": "^7.9.0",
@@ -45,6 +46,7 @@
     "husky": "^4.3.0",
     "jest": "^26.4.2",
     "prettier": "^2.1.2",
-    "pretty-quick": "^3.0.2"
+    "pretty-quick": "^3.0.2",
+    "yargs": "^16.1.0"
   }
 }

--- a/scripts/createTitle.js
+++ b/scripts/createTitle.js
@@ -27,8 +27,8 @@ async function createTitle(args) {
   const params = {
     ghToken: 'aaaaaaaa',
     chToken: process.env.CH_TOKEN,
-    prependType: true,
-    fetchStoryNameFlag: 'ch',
+    addStoryType: true,
+    useStoryNameTrigger: 'ch',
     pullRequest,
     repository: {},
     dryRun: true,

--- a/scripts/createTitle.js
+++ b/scripts/createTitle.js
@@ -6,7 +6,7 @@ const help = `
 
     Basic Usage:
 
-    node scripts/createTitle.js \\
+    node -r @babel/register scripts/createTitle.js \\
         --prTitle 'ch' \\
         --branchName 'user/ch12345/name-of-a-ticket' \\
     ;

--- a/scripts/createTitle.js
+++ b/scripts/createTitle.js
@@ -1,6 +1,6 @@
 const { argv } = require('yargs');
 
-const { fetchStorysAndUpdatePr } = require('../index');
+const { fetchStoryAndUpdatePr } = require('../index');
 
 const help = `
 
@@ -33,7 +33,7 @@ async function createTitle(args) {
     repository: {},
     dryRun: true,
   };
-  const newPrTitle = await fetchStorysAndUpdatePr(params);
+  const newPrTitle = await fetchStoryAndUpdatePr(params);
   console.log(`Created Title: ${newPrTitle}`);
 }
 

--- a/scripts/createTitle.js
+++ b/scripts/createTitle.js
@@ -1,0 +1,55 @@
+const { argv } = require('yargs');
+
+const { fetchStorysAndUpdatePr } = require('../index');
+
+const help = `
+
+    Basic Usage:
+
+    node scripts/createTitle.js \\
+        --prTitle 'ch' \\
+        --branchName 'user/ch12345/name-of-a-ticket' \\
+    ;
+`;
+
+async function createTitle(args) {
+  const { prTitle, branchName } = args;
+  if (prTitle === undefined || branchName === undefined) {
+    throw new Error(help);
+  }
+  if (!process.env.CH_TOKEN) {
+    throw new Error('CH_TOKEN env var is unset');
+  }
+  const pullRequest = {
+    title: prTitle,
+    head: { ref: branchName },
+  };
+  const params = {
+    ghToken: 'aaaaaaaa',
+    chToken: process.env.CH_TOKEN,
+    prependType: true,
+    fetchStoryNameFlag: 'ch',
+    pullRequest,
+    repository: {},
+    dryRun: true,
+  };
+  const newPrTitle = await fetchStorysAndUpdatePr(params);
+  console.log(`Created Title: ${newPrTitle}`);
+}
+
+function exit(err) {
+  console.error(err);
+  process.exit(1);
+}
+
+async function main() {
+  try {
+    await createTitle(argv);
+  } catch (err) {
+    exit(err);
+  }
+}
+
+if (require.main === module) {
+  main();
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -824,6 +824,17 @@
     "@babel/types" "^7.4.4"
     esutils "^2.0.2"
 
+"@babel/register@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/register/-/register-7.12.1.tgz#cdb087bdfc4f7241c03231f22e15d211acf21438"
+  integrity sha512-XWcmseMIncOjoydKZnWvWi0/5CUCD+ZYKhRwgYlWOrA8fGZ/FjuLRpqtIhLOVD/fvR1b9DQHtZPn68VvhpYf+Q==
+  dependencies:
+    find-cache-dir "^2.0.0"
+    lodash "^4.17.19"
+    make-dir "^2.1.0"
+    pirates "^4.0.0"
+    source-map-support "^0.5.16"
+
 "@babel/runtime@^7.8.4":
   version "7.11.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.11.2.tgz#f549c13c754cc40b87644b9fa9f09a6a95fe0736"
@@ -1760,6 +1771,15 @@ cliui@^6.0.0:
     strip-ansi "^6.0.0"
     wrap-ansi "^6.2.0"
 
+cliui@^7.0.2:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-7.0.3.tgz#ef180f26c8d9bff3927ee52428bfec2090427981"
+  integrity sha512-Gj3QHTkVMPKqwP3f7B4KPkBZRMR9r4rfi5bXFpg1a+Svvj8l7q5CnkBkVQzfxT5DFSsGk2+PascOgL0JYkL2kw==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.0"
+    wrap-ansi "^7.0.0"
+
 clubhouse-lib@^0.10.0:
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/clubhouse-lib/-/clubhouse-lib-0.10.0.tgz#4a09f2a501df16ce353389472f51f3306dce10dd"
@@ -1817,6 +1837,11 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
   dependencies:
     delayed-stream "~1.0.0"
+
+commondir@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
+  integrity sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=
 
 compare-versions@^3.6.0:
   version "3.6.0"
@@ -2151,6 +2176,11 @@ escalade@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.0.tgz#e8e2d7c7a8b76f6ee64c2181d6b8151441602d4e"
   integrity sha512-mAk+hPSO8fLDkhV7V0dXazH5pDc6MrjBTPyD3VeKzxnVFjH1MIxbCdqGZB9O8+EwWakZs3ZCbDS4IpRt79V1ig==
+
+escalade@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
+  integrity sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==
 
 escape-string-regexp@^1.0.5:
   version "1.0.5"
@@ -2510,12 +2540,28 @@ fill-range@^7.0.1:
   dependencies:
     to-regex-range "^5.0.1"
 
+find-cache-dir@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-2.1.0.tgz#8d0f94cd13fe43c6c7c261a0d86115ca918c05f7"
+  integrity sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==
+  dependencies:
+    commondir "^1.0.1"
+    make-dir "^2.0.0"
+    pkg-dir "^3.0.0"
+
 find-up@^2.0.0, find-up@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
   integrity sha1-RdG35QbHF93UgndaK3eSCjwMV6c=
   dependencies:
     locate-path "^2.0.0"
+
+find-up@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-3.0.0.tgz#49169f1d7993430646da61ecc5ae355c21c97b73"
+  integrity sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==
+  dependencies:
+    locate-path "^3.0.0"
 
 find-up@^4.0.0, find-up@^4.1.0:
   version "4.1.0"
@@ -2597,7 +2643,7 @@ gensync@^1.0.0-beta.1:
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.1.tgz#58f4361ff987e5ff6e1e7a210827aa371eaac269"
   integrity sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg==
 
-get-caller-file@^2.0.1:
+get-caller-file@^2.0.1, get-caller-file@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
@@ -3703,6 +3749,14 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
+locate-path@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-3.0.0.tgz#dbec3b3ab759758071b58fe59fc41871af21400e"
+  integrity sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==
+  dependencies:
+    p-locate "^3.0.0"
+    path-exists "^3.0.0"
+
 locate-path@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-5.0.0.tgz#1afba396afd676a6d42504d0a67a3a7eb9f62aa0"
@@ -3751,6 +3805,14 @@ loose-envify@^1.0.0:
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
+
+make-dir@^2.0.0, make-dir@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-2.1.0.tgz#5f0310e18b8be898cc07009295a30ae41e91e6f5"
+  integrity sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==
+  dependencies:
+    pify "^4.0.1"
+    semver "^5.6.0"
 
 make-dir@^3.0.0:
   version "3.1.0"
@@ -4115,7 +4177,7 @@ p-limit@^1.1.0:
   dependencies:
     p-try "^1.0.0"
 
-p-limit@^2.2.0:
+p-limit@^2.0.0, p-limit@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.3.0.tgz#3dd33c647a214fdfffd835933eb086da0dc21db1"
   integrity sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==
@@ -4128,6 +4190,13 @@ p-locate@^2.0.0:
   integrity sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=
   dependencies:
     p-limit "^1.1.0"
+
+p-locate@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-3.0.0.tgz#322d69a05c0264b25997d9f40cd8a891ab0064a4"
+  integrity sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==
+  dependencies:
+    p-limit "^2.0.0"
 
 p-locate@^4.1.0:
   version "4.1.0"
@@ -4237,7 +4306,12 @@ pify@^2.0.0:
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
   integrity sha1-7RQaasBDqEnqWISY59yosVMw6Qw=
 
-pirates@^4.0.1:
+pify@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/pify/-/pify-4.0.1.tgz#4b2cd25c50d598735c50292224fd8c6df41e3231"
+  integrity sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==
+
+pirates@^4.0.0, pirates@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.1.tgz#643a92caf894566f91b2b986d2c66950a8e2fb87"
   integrity sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==
@@ -4250,6 +4324,13 @@ pkg-dir@^2.0.0:
   integrity sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=
   dependencies:
     find-up "^2.1.0"
+
+pkg-dir@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-3.0.0.tgz#2749020f239ed990881b1f71210d51eb6523bea3"
+  integrity sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==
+  dependencies:
+    find-up "^3.0.0"
 
 pkg-dir@^4.2.0:
   version "4.2.0"
@@ -4635,7 +4716,7 @@ semver-regex@^2.0.0:
   resolved "https://registry.yarnpkg.com/semver-regex/-/semver-regex-2.0.0.tgz#a93c2c5844539a770233379107b38c7b4ac9d338"
   integrity sha512-mUdIBBvdn0PLOeP3TEkMH7HHeUP3GjsXCwKarjv/kGmUFOYg1VqEemKhoQpWMu6X2I8kHeuVdGibLGkVK+/5Qw==
 
-"semver@2 || 3 || 4 || 5", semver@^5.4.1, semver@^5.5.0:
+"semver@2 || 3 || 4 || 5", semver@^5.4.1, semver@^5.5.0, semver@^5.6.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -4764,7 +4845,7 @@ source-map-resolve@^0.5.0:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
-source-map-support@^0.5.13, source-map-support@^0.5.6:
+source-map-support@^0.5.13, source-map-support@^0.5.16, source-map-support@^0.5.6:
   version "0.5.19"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
   integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
@@ -5382,6 +5463,15 @@ wrap-ansi@^6.2.0:
     string-width "^4.1.0"
     strip-ansi "^6.0.0"
 
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
@@ -5424,6 +5514,11 @@ y18n@^4.0.0:
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
   integrity sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==
 
+y18n@^5.0.2:
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.5.tgz#8769ec08d03b1ea2df2500acef561743bbb9ab18"
+  integrity sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg==
+
 yaml@^1.10.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.0.tgz#3b593add944876077d4d683fee01081bd9fff31e"
@@ -5436,6 +5531,11 @@ yargs-parser@^18.1.2:
   dependencies:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
+
+yargs-parser@^20.2.2:
+  version "20.2.3"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.3.tgz#92419ba867b858c868acf8bae9bf74af0dd0ce26"
+  integrity sha512-emOFRT9WVHw03QSvN5qor9QQT9+sw5vwxfYweivSMHTcAXPefwVae2FjO7JJjj8hCE4CzPOPeFM83VwT29HCww==
 
 yargs@^15.3.1:
   version "15.4.1"
@@ -5453,3 +5553,16 @@ yargs@^15.3.1:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^18.1.2"
+
+yargs@^16.1.0:
+  version "16.1.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-16.1.0.tgz#fc333fe4791660eace5a894b39d42f851cd48f2a"
+  integrity sha512-upWFJOmDdHN0syLuESuvXDmrRcWd1QafJolHskzaw79uZa7/x53gxQKiR07W59GWY1tFhhU/Th9DrtSfpS782g==
+  dependencies:
+    cliui "^7.0.2"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.0"
+    y18n "^5.0.2"
+    yargs-parser "^20.2.2"


### PR DESCRIPTION
Story Details: https://app.clubhouse.io/farmersdog/story/46063 
 
### Context

There are some edge cases where the engineers don't want to use the clubhouse story name as the PR title. Also, it was requested we standardize always prepending `(type)` to the title to alleviate any confusion where and when that happens.

### Analysis

We need some kind of 'trigger' to tell the action, 'hey, i want you to use the clubhouse story name' so that engineers can conditionally control that part. For both that functionality and prepending the story type, we should make it configurable in case anyone using this outside our org want's to tweak it.

### Solution

- Add inputs to control using the story's `story_type` and the keyword that triggers using the story's name.
- Add new function `getTitle` that creates a title in the correct format based on all the options used.
- Add tests for `getTitle`.
- Abstract internal logic away from the action interface so we can invoke through other means, add `dryRun` switch.
- Add a script `createTitle.js` for manual integration testing with clubhouse.
- Add a workflow to checkout and run the action locally so we can see the changes we are making run on PRs.
- Update README.

### Testing

I ran the scenarios on this PR using the new action workflow, the renaming is present below in the history of the PR.
<img width="787" alt="Screen Shot 2020-11-04 at 1 46 49 PM" src="https://user-images.githubusercontent.com/15093505/98155454-44a3fe00-1ea4-11eb-8489-eb55fe078d56.png">
<img width="897" alt="Screen Shot 2020-11-04 at 1 46 56 PM" src="https://user-images.githubusercontent.com/15093505/98155467-48d01b80-1ea4-11eb-8bd2-608c8a378532.png">

 If you pull the branch, it's also possible to test creating titles one off using real clubhouse stories with the [createTitle.js](https://github.com/farmersdog/clubhouse-pr/blob/315aa048cee13b60c33176a5a6ac1f05bbd574a9/scripts/createTitle.js) script.

First, get setup by running
```
export CH_TOKEN=<your-pat-from-clubhouse>
yarn
```

If you run the below, where `ch12345` is a real story ID on our clubhouse...
```
node -r @babel/register scripts/createTitle.js --prTitle 'ch' --branchName 'user/ch12345/name-of-a-ticket'
```
You should end up with...
```
(type-of-story) Story Name from Clubhouse [ch12345]
```

Alternatively, if you use a prTitle other than `ch`...
```
node -r @babel/register scripts/createTitle.js --prTitle 'My Custom Title' --branchName 'user/ch12345/name-of-a-ticket'
```
You should end up with...
```
(type-of-story) My Custom Title [ch12345]
```