### PR TITLE
Parse addStoryType string value to boolean

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -14828,7 +14828,9 @@ async function run() {
     const params = {
       ghToken,
       chToken,
-      addStoryType: core.getInput('addStoryType') ? core.getBooleanInput('addStoryType') : true,
+      addStoryType: core.getInput('addStoryType')
+        ? core.getBooleanInput('addStoryType')
+        : true,
       useStoryNameTrigger: core.getInput('useStoryNameTrigger'),
       pullRequest,
       repository,

--- a/dist/index.js
+++ b/dist/index.js
@@ -161,7 +161,7 @@ async function run() {
     const params = {
       ghToken,
       chToken,
-      addStoryType: core.getInput('addStoryType'),
+      addStoryType: core.getInput('addStoryType') !== 'false',
       useStoryNameTrigger: core.getInput('useStoryNameTrigger'),
       pullRequest,
       repository,

--- a/index.js
+++ b/index.js
@@ -144,7 +144,7 @@ async function run() {
     const params = {
       ghToken,
       chToken,
-      addStoryType: core.getInput('addStoryType'),
+      addStoryType: core.getInput('addStoryType') !== 'false',
       useStoryNameTrigger: core.getInput('useStoryNameTrigger'),
       pullRequest,
       repository,

--- a/index.test.js
+++ b/index.test.js
@@ -41,6 +41,14 @@ describe('Update Pull Request', () => {
       await action.run();
       expect(core.setFailed).toHaveBeenCalledTimes(1);
     });
+
+    test('should parse addStoryType to boolean', async () => {
+      inputs.ghToken = '123';
+      inputs.chToken = '123';
+      inputs.addStoryType = 'true';
+      await action.run();
+      expect(core.getBooleanInput).toHaveBeenCalledWith('addStoryType');
+    });
   });
 
   describe('Creating the PR Title', () => {


### PR DESCRIPTION
YAML booleans are actually strings when retrieving them with `core.getInput()`, so they need to get parsed to a boolean value. 

I've applied a fix for the `addStoryType` input. It defaults to `true`.