### PR TITLE
Fix PR body update to not show null and consider previous step PR updates

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -85,7 +85,15 @@ async function updatePullRequest(ghToken, pullRequest, repository, metadata) {
   } = repository;
   const { title, url } = metadata;
   const originalBody = pullRequest.body;
-  const body = `Story Details: ${url} \n \n${originalBody}`;
+  let body = `Story Details: ${url}`;
+
+  if (originalBody) {
+    if (originalBody.includes(body)) {
+      body = originalBody;
+    } else {
+      body += `\n\n${originalBody}`;
+    }
+  }
 
   try {
     core.info(`Updating Title: ${title}`);
@@ -157,7 +165,13 @@ async function run() {
     core.setSecret('ghToken');
     core.setSecret('chToken');
 
-    const { pull_request: pullRequest, repository } = github.context.payload;
+    const octokit = github.getOctokit(ghToken);
+    const { number: prNumber, repository } = github.context.payload;
+    const { data: pullRequest } = await octokit.pulls.get({
+      repo: repository.name,
+      owner: repository.owner.login,
+      pull_number: prNumber,
+    });
     const params = {
       ghToken,
       chToken,

--- a/index.js
+++ b/index.js
@@ -68,7 +68,15 @@ async function updatePullRequest(ghToken, pullRequest, repository, metadata) {
   } = repository;
   const { title, url } = metadata;
   const originalBody = pullRequest.body;
-  const body = `Story Details: ${url} \n \n${originalBody}`;
+  let body = `Story Details: ${url}`;
+
+  if (originalBody) {
+    if (originalBody.includes(body)) {
+      body = originalBody;
+    } else {
+      body += `\n\n${originalBody}`;
+    }
+  }
 
   try {
     core.info(`Updating Title: ${title}`);
@@ -140,7 +148,13 @@ async function run() {
     core.setSecret('ghToken');
     core.setSecret('chToken');
 
-    const { pull_request: pullRequest, repository } = github.context.payload;
+    const octokit = github.getOctokit(ghToken);
+    const { number: prNumber, repository } = github.context.payload;
+    const { data: pullRequest } = await octokit.pulls.get({
+      repo: repository.name,
+      owner: repository.owner.login,
+      pull_number: prNumber,
+    });
     const params = {
       ghToken,
       chToken,


### PR DESCRIPTION
This PR fixes two bugs:
1. If the body is empty, then `pullRequest.body` was `null` and it got appended to the body, producing a result like:

```
Story Details: foo

null
```

2. `github.context.payload.pull_request` contains the PR's state from the beginning of the workflow. If one of the steps that runs before `clubhouse-pr` already updated the PRs body, then it got overriden here. 