### PR TITLE
Optionally mark the GitHub Action as failed if the PR isn't connected to any Clubhouse story

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ This action is configured to extract the clubhouse story id form either the bran
 
 **Default** `ch`
 
+### `throwErrorIfNoChStory`
+
+**Optional** Should this GitHub Action throw an error if the PR is not connected to any Clubhouse story
+
+**Default** `true`
+
 ## Outputs
 
 ### `prTitle`

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,10 @@ inputs:
     description: 'When a PR is opened with this string as the title, fetch the story name from clubhouse'
     required: false
     default: 'ch'
+  throwErrorIfNoChStory:
+    description: Should this GitHub Action throw an error if the PR is not connected to any Clubhouse story
+    required: false
+    default: true
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ function formatMatches(matches) {
   return values;
 }
 
-function getStoryIds(pullRequest) {
+function getStoryIds(pullRequest, throwErrorIfNoChStory) {
   const branchName = pullRequest.head.ref;
   // Only when a Github user formats their branchName as: text/ch123/something
   const branchStoryIds = branchName.match(/\/(ch)(\d+)\//g);
@@ -43,21 +43,23 @@ function getStoryIds(pullRequest) {
     return storyIds;
   }
 
-  return core.setFailed(
-    'Action failed to find a Clubhouse ID in both the branch name and PR title.'
-  );
+  const message = 'Action failed to find a Clubhouse ID in both the branch name and PR title.';
+
+  if (throwErrorIfNoChStory) {
+    throw new Error(message);
+  }
+
+  core.info(message);
+
+  return [];
 }
 
 async function getClubhouseStory(client, storyIds) {
   // Even if there's more than one storyId, fetch only first story name:
-  try {
-    return client
-      .getStory(storyIds[0])
-      .then((res) => res)
-      .catch((err) => err.response);
-  } catch (error) {
-    return core.setFailed(error);
-  }
+  return client
+    .getStory(storyIds[0])
+    .then((res) => res)
+    .catch((err) => err.response);
 }
 
 async function updatePullRequest(ghToken, pullRequest, repository, metadata) {
@@ -100,10 +102,16 @@ async function fetchStoryAndUpdatePr(params) {
     useStoryNameTrigger,
     pullRequest,
     repository,
+    throwErrorIfNoChStory,
     dryRun,
   } = params;
   const client = Clubhouse.create(chToken);
-  const storyIds = getStoryIds(pullRequest);
+  const storyIds = getStoryIds(pullRequest, throwErrorIfNoChStory);
+
+  if (!storyIds) {
+    return null;
+  }
+
   const story = await getClubhouseStory(client, storyIds);
   const newTitle = getTitle(
     storyIds,
@@ -148,6 +156,7 @@ async function run() {
       useStoryNameTrigger: core.getInput('useStoryNameTrigger'),
       pullRequest,
       repository,
+      throwErrorIfNoChStory: core.getInput('throwErrorIfNoChStory') !== 'false',
       dryRun: false,
     };
     const prTitle = await fetchStoryAndUpdatePr(params);


### PR DESCRIPTION
In my use case, not all PRs are connected to Clubhouse stories and also this step is not the last one in my workflow. 

This PR adds a new variable with which one can control if the step should be marked as failed or not when the PR is not connected to any story.