### PR TITLE
Update getTitle to check if it already has needed info

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -105,7 +105,16 @@ function getTitle(storyIds, story, prTitle, useStoryNameTrigger, addStoryType) {
   const formattedStoryIds = storyIds.map((id) => `[sc-${id}]`).join(' ');
   const basePrTitle = prTitle === useStoryNameTrigger ? story.name : prTitle;
   const typePrefix = addStoryType ? `(${story.story_type}) ` : '';
-  const newTitle = `${typePrefix}${basePrTitle} ${formattedStoryIds}`;
+  let newTitle = basePrTitle;
+
+  if (basePrTitle.search(typePrefix) < 0) {
+    newTitle = `${typePrefix}${newTitle}`;
+  }
+
+  if (basePrTitle.search(formattedStoryIds) < 0) {
+    newTitle = `${newTitle} ${formattedStoryIds}`;
+  }
+
   return newTitle;
 }
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -107,11 +107,11 @@ function getTitle(storyIds, story, prTitle, useStoryNameTrigger, addStoryType) {
   const typePrefix = addStoryType ? `(${story.story_type}) ` : '';
   let newTitle = basePrTitle;
 
-  if (basePrTitle.search(typePrefix) < 0) {
+  if (basePrTitle.indexOf(typePrefix) < 0) {
     newTitle = `${typePrefix}${newTitle}`;
   }
 
-  if (basePrTitle.search(formattedStoryIds) < 0) {
+  if (basePrTitle.indexOf(formattedStoryIds) < 0) {
     newTitle = `${newTitle} ${formattedStoryIds}`;
   }
 

--- a/index.js
+++ b/index.js
@@ -88,7 +88,16 @@ function getTitle(storyIds, story, prTitle, useStoryNameTrigger, addStoryType) {
   const formattedStoryIds = storyIds.map((id) => `[sc-${id}]`).join(' ');
   const basePrTitle = prTitle === useStoryNameTrigger ? story.name : prTitle;
   const typePrefix = addStoryType ? `(${story.story_type}) ` : '';
-  const newTitle = `${typePrefix}${basePrTitle} ${formattedStoryIds}`;
+  let newTitle = basePrTitle;
+
+  if (basePrTitle.search(typePrefix) < 0) {
+    newTitle = `${typePrefix}${newTitle}`;
+  }
+
+  if (basePrTitle.search(formattedStoryIds) < 0) {
+    newTitle = `${newTitle} ${formattedStoryIds}`;
+  }
+
   return newTitle;
 }
 

--- a/index.js
+++ b/index.js
@@ -90,11 +90,11 @@ function getTitle(storyIds, story, prTitle, useStoryNameTrigger, addStoryType) {
   const typePrefix = addStoryType ? `(${story.story_type}) ` : '';
   let newTitle = basePrTitle;
 
-  if (basePrTitle.search(typePrefix) < 0) {
+  if (basePrTitle.indexOf(typePrefix) < 0) {
     newTitle = `${typePrefix}${newTitle}`;
   }
 
-  if (basePrTitle.search(formattedStoryIds) < 0) {
+  if (basePrTitle.indexOf(formattedStoryIds) < 0) {
     newTitle = `${newTitle} ${formattedStoryIds}`;
   }
 

--- a/index.test.js
+++ b/index.test.js
@@ -82,6 +82,28 @@ describe('Update Pull Request', () => {
         'A PR title that should not be replaced [sc-5678]'
       );
     });
+
+    test('should not duplicate story number if already present', async () => {
+      const prTitle = action.getTitle(
+        ['5678'],
+        { name: 'A clubhouse story name [sc-5678]', story_type: 'feature' },
+        'sc-',
+        'sc-',
+        true
+      );
+      expect(prTitle).toEqual('(feature) A clubhouse story name [sc-5678]');
+    });
+
+    test('should not duplicate story type if already present', async () => {
+      const prTitle = action.getTitle(
+        ['5678'],
+        { name: '(feature) A clubhouse story name', story_type: 'feature' },
+        'sc-',
+        'sc-',
+        true
+      );
+      expect(prTitle).toEqual('(feature) A clubhouse story name [sc-5678]');
+    });
   });
 
   describe('getStoryIds', () => {


### PR DESCRIPTION
## ASK

As a developer, I often will pro-actively add the desired PR title criteria, and when I do so I do not want the PR bot to duplicate that information.

## Context

Example: https://github.com/farmersdog/api/pull/3316

Search of the PRs that have had this happen: https://github.com/farmersdog/api/pulls?q=%22%28feature%29+%28feature%29%22

## Solution

Do a search for the strings we plan to add and refrain from adding them if they are already present.